### PR TITLE
docs: update Python version badges/text to 3.10+ (follows PR #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/memvee/"><img src="https://img.shields.io/pypi/v/memvee.svg" alt="PyPI version"></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.13+-blue.svg" alt="Python 3.13+"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://github.com/pydantic/pydantic-ai"><img src="https://img.shields.io/badge/Powered%20by-Pydantic%20AI-E92063?logo=pydantic&logoColor=white" alt="Pydantic AI"></a>
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/memvee/"><img src="https://img.shields.io/pypi/v/memvee.svg" alt="PyPI"></a>
-  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.13+-blue.svg" alt="Python 3.13+"></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
   <a href="https://github.com/pydantic/pydantic-ai"><img src="https://img.shields.io/badge/Powered%20by-Pydantic%20AI-E92063?logo=pydantic&logoColor=white" alt="Pydantic AI"></a>
 </p>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.13+
+- Python 3.10+
 - OpenAI API key (for default adapters)
 
 ## Install


### PR DESCRIPTION
Summary

- Update docs to reflect Python 3.10+ support.
- Aligns badges/text with packaging and CI from PR #31.
- No functional code changes.

Changes

- README.md: Update Python version badge/alt to 3.10+.
- docs/index.md: Update Python version badge/alt to 3.10+.
- docs/installation.md: Update requirement text to “Python 3.10+”.

Related

- Follows up on PR #31 (relax Python version requirement).

Checklist

- [ ] Tests pass (make all) — docs-only; no code changes
- [x] Docs updated (if user-facing)